### PR TITLE
Verify type of input for editor scene

### DIFF
--- a/Assets/Scenes/EditorScene.unity
+++ b/Assets/Scenes/EditorScene.unity
@@ -676,8 +676,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 247112759}
   m_HandleRect: {fileID: 247112758}
   m_Direction: 2
-  m_Value: 0.9999995
-  m_Size: 0.75849056
+  m_Value: 0.9999996
+  m_Size: 0.73018867
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -13701,8 +13701,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 391362985}
   m_HandleRect: {fileID: 391362984}
   m_Direction: 2
-  m_Value: 0.9999966
-  m_Size: 0.95714283
+  m_Value: 0.99999815
+  m_Size: 0.92142856
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -17847,11 +17847,11 @@ MonoBehaviour:
       - m_Target: {fileID: 2049420947}
         m_TargetAssemblyTypeName: TilePopupSystem_wrapper, Assembly-CSharp
         m_MethodName: popupConsoleDropDown
-        m_Mode: 3
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0

--- a/Assets/Systems/LevelEditor/TilePopupSystem.cs
+++ b/Assets/Systems/LevelEditor/TilePopupSystem.cs
@@ -240,15 +240,61 @@ public class TilePopupSystem : FSystem
 
 	public void popupConsoleDropDown(int newData)
 	{
+		Debug.Log("hi new data in popupConsoleDropDown: " + newData);
 		if (selectedObject != null)
 			((Console)selectedObject).type = newData;
 	}
 
 	public void popupConsoleValue(string newData)
-	{	
+	{
 		Debug.Log("hi new data in popupConsoleValue: " + newData);
-		if (selectedObject != null)
-			((Console)selectedObject).value = newData;
+
+		// If selectedObject is null, skip further processing
+		if (selectedObject == null) return;
+
+		// Get the Console object
+		Console console = (Console)selectedObject;
+
+		// Check the value of console.type and process accordingly
+		switch (console.type)
+		{
+			case -1:
+				// If type is -1, skip processing
+				return;
+
+			case 0:
+				// If type is 0, check if newData is a number
+				if (!int.TryParse(newData, out _))
+				{
+					console.value = ""; // If not a number, clear the value
+				}
+				else
+				{
+					console.value = newData; // Otherwise, update the value
+				}
+				break;
+
+			case 1:
+				// If type is 1, check if newData is "true" or "false"
+				if (newData != "true" && newData != "false")
+				{
+					console.value = ""; // If not "true" or "false", clear the value
+				}
+				else
+				{
+					console.value = newData; // Otherwise, update the value
+				}
+				break;
+
+			case 2:
+				// If type is 2, accept any string value
+				console.value = newData;
+				break;
+
+			default:
+				// For unknown type values, skip processing
+				return;
+		}
 	}
 
 

--- a/Assets/Systems/LevelGenerator.cs
+++ b/Assets/Systems/LevelGenerator.cs
@@ -366,13 +366,43 @@ public class LevelGenerator : FSystem {
 		{
 			{ 0, "int" },
 			{ 1, "boolean" },
+			{ 2, "string" },
 		};
 		if (tooltipContent != null && type != -1 && value != "")
 		{
-			tooltipContent.text = $"active moi avec une action ! \ndonne moi une variable (type: {varTypeEnum[type]} valeur: {value})";
+			if (ValidateValue(type, value))
+			{
+				tooltipContent.text = $"active moi avec une action ! \ndonne moi une variable (type: {varTypeEnum[type]} valeur: {value})";
+			}
+			else
+			{
+				tooltipContent.text = "active moi avec une action !";
+				Debug.LogWarning($"Invalid value '{value}' for type {type}");
+			}		
 		}
 		if (state == 1)
 			activable.AddComponent<TurnedOn>();
+	}
+
+	private bool ValidateValue(int type, string value)
+	{
+		switch (type)
+		{
+			case -1:
+				return false; // -1 is not a valid type
+
+			case 0:
+				return int.TryParse(value, out _); // Valid if the value is an integer
+
+			case 1:
+				return value == "true" || value == "false"; // Valid if the value is a boolean
+
+			case 2:
+				return true; // Any string is valid for type 2
+
+			default:
+				return false; // Unknown type
+		}
 	}
 
 	private void createSpawnExit(int gridX, int gridY, bool type, bool hideExit = false){


### PR DESCRIPTION
nothing will be affected to the terminal if the input variable is of the wrong type.
For example:
![6671735049927_ pic](https://github.com/user-attachments/assets/b8085c8f-41b4-49ef-b534-7dc3b7a3af8d)
will not be displayed on the terminal:
![6681735049944_ pic](https://github.com/user-attachments/assets/f7ca9f72-011f-4b88-b4ba-dfdd564f44c9)
